### PR TITLE
Fix NULL pointer dereferences and improve compatibility with COM

### DIFF
--- a/src/FAudio.c
+++ b/src/FAudio.c
@@ -1206,7 +1206,7 @@ uint32_t FAudioSourceVoice_FlushSourceBuffers(
 	/* Go through each buffer, send an event for each one before deleting */
 	while (entry != NULL)
 	{
-		if (voice->src.callback->OnBufferEnd != NULL)
+		if (voice->src.callback != NULL && voice->src.callback->OnBufferEnd != NULL)
 		{
 			voice->src.callback->OnBufferEnd(
 				voice->src.callback,

--- a/src/FAudio.c
+++ b/src/FAudio.c
@@ -33,11 +33,16 @@ uint32_t FAudioCreate(
 	uint32_t Flags,
 	FAudioProcessor XAudio2Processor
 ) {
+	FAudio_Construct(ppFAudio);
+	FAudio_Initialize(*ppFAudio, Flags, XAudio2Processor);
+	return 0;
+}
+
+uint32_t FAudio_Construct(FAudio **ppFAudio) {
 	FAudio_PlatformAddRef();
 	*ppFAudio = (FAudio*) FAudio_malloc(sizeof(FAudio));
 	FAudio_zero(*ppFAudio, sizeof(FAudio));
 	(*ppFAudio)->refcount = 1;
-	FAudio_Initialize(*ppFAudio, Flags, XAudio2Processor);
 	return 0;
 }
 

--- a/src/FAudio.c
+++ b/src/FAudio.c
@@ -44,12 +44,13 @@ uint32_t FAudioCreate(
 uint32_t FAudio_AddRef(FAudio *audio)
 {
 	audio->refcount += 1;
-	return 0;
+	return audio->refcount;
 }
 
 uint32_t FAudio_Release(FAudio *audio)
 {
 	audio->refcount -= 1;
+	uint32_t refcount = audio->refcount;
 	if (audio->refcount == 0)
 	{
 		FAudio_StopEngine(audio);
@@ -58,7 +59,7 @@ uint32_t FAudio_Release(FAudio *audio)
 		FAudio_free(audio);
 		FAudio_PlatformRelease();
 	}
-	return 0;
+	return refcount;
 }
 
 uint32_t FAudio_GetDeviceCount(FAudio *audio, uint32_t *pCount)

--- a/src/FAudio.h
+++ b/src/FAudio.h
@@ -378,6 +378,8 @@ FAUDIOAPI uint32_t FAudioCreate(
 	FAudioProcessor XAudio2Processor
 );
 
+FAUDIOAPI uint32_t FAudio_Construct(FAudio **ppFAudio);	/* Only for COM interopability - not needed anywhere else */
+
 FAUDIOAPI uint32_t FAudio_AddRef(FAudio *audio);
 
 FAUDIOAPI uint32_t FAudio_Release(FAudio *audio);


### PR DESCRIPTION
COM AddRef/Release return the new reference count. Changing FAudio_AddRef/Release to do this as well prevents a duplicated reference counter in the C++ wrapper.

XAudio2Create allocates the XAudio implementation and initializes the engine. The COM-wrapper needs to be able to allocate without initializing in CreateInstance. I saw no other solution than to split off this functionality from FAudioCreate to another public function (FAudio_Construct). 
