### PR TITLE
Fix issues with EffectChain and effect-parameters.

### DIFF
--- a/src/FAudio.c
+++ b/src/FAudio.c
@@ -630,6 +630,7 @@ uint32_t FAudioVoice_SetEffectParameters(
 		voice->effects.parameters[EffectIndex] = FAudio_malloc(
 			ParametersByteSize
 		);
+		voice->effects.parameterSizes[EffectIndex] = ParametersByteSize;
 	}
 	if (voice->effects.parameterSizes[EffectIndex] < ParametersByteSize)
 	{
@@ -637,6 +638,7 @@ uint32_t FAudioVoice_SetEffectParameters(
 			voice->effects.parameters[EffectIndex],
 			ParametersByteSize
 		);
+		voice->effects.parameterSizes[EffectIndex] = ParametersByteSize;
 	}
 	voice->effects.parameterUpdates[EffectIndex] = 1;
 	FAudio_memcpy(

--- a/src/FAudio.c
+++ b/src/FAudio.c
@@ -550,7 +550,7 @@ uint32_t FAudioVoice_SetEffectChain(
 			 * IsOutputFormatSupported and GetRegistrationPropertiesFunc
 			 */
 			FAPOBase_AddRef(
-				(FAPOBase*) voice->effects.desc[i].pEffect
+				(FAPOBase*) pEffectChain->pEffectDescriptors[i].pEffect
 			);
 		}
 		voice->effects.count = pEffectChain->EffectCount;


### PR DESCRIPTION
With these changes applied the XAudio2 SDK sample XAudio2CustomAPO works with the FAudio COM DLLs.