### PR TITLE
Clear voice->src.bufferList when all buffers are removed

### DIFF
--- a/src/FAudio.c
+++ b/src/FAudio.c
@@ -1118,6 +1118,7 @@ uint32_t FAudioSourceVoice_FlushSourceBuffers(
 	else
 	{
 		voice->src.curBufferOffset = 0;
+		voice->src.bufferList = NULL;
 	}
 
 	/* Go through each buffer, send an event for each one before deleting */


### PR DESCRIPTION
This fixes a potential infinite loop in voice->src.bufferList after a FlushSourceBuffers and SubmitSourceBuffer combo.