### PR TITLE
Support WAVEFORMATEXTENSIBLE formats with a standard PCM subformat

### DIFF
--- a/src/FAudio_internal.h
+++ b/src/FAudio_internal.h
@@ -240,6 +240,7 @@ void FAudio_free(void *ptr);
 void FAudio_zero(void *ptr, size_t size);
 void FAudio_memcpy(void *dst, const void *src, size_t size);
 void FAudio_memmove(void *dst, void *src, size_t size);
+int FAudio_memcmp(const void *ptr1, const void *ptr2, size_t size);
 size_t FAudio_strlen(const char *ptr);
 int FAudio_strcmp(const char *str1, const char *str2);
 void FAudio_strlcpy(char *dst, const char *src, size_t len);

--- a/src/FAudio_platform_sdl2.c
+++ b/src/FAudio_platform_sdl2.c
@@ -503,6 +503,11 @@ void FAudio_memmove(void *dst, void *src, size_t size)
 	SDL_memmove(dst, src, size);
 }
 
+int FAudio_memcmp(const void *ptr1, const void *ptr2, size_t size)
+{
+	return SDL_memcmp(ptr1, ptr2, size);
+}
+
 size_t FAudio_strlen(const char *ptr)
 {
 	return SDL_strlen(ptr);


### PR DESCRIPTION
I cleaned up the WAVEFORMATEXTENSIBLE patch per your suggestions.

The 3 supported GUIDs are declared in the function itself, seemed like the easiest solution. They have no use in the rest of the library. In C99 it's possible to use the struct-initializer directly as an argument to memcmp but that won't work with VS2010.