### PR TITLE
Enhance effect chain support in FAudio

### DIFF
--- a/src/FAudioFX.c
+++ b/src/FAudioFX.c
@@ -220,7 +220,6 @@ uint32_t FAudioFXReverb_IsInputFormatSupported(
 	else
 	{
 		SET_SUPPORTED_FIELD(nChannels, 1);
-		result = 1;
 	}
 
 #undef SET_SUPPORTED_FIELD
@@ -259,22 +258,15 @@ uint32_t FAudioFXReverb_IsOutputFormatSupported(
 	/* number of input / output channels */
 	if (pInputFormat->nChannels == 1 || pInputFormat->nChannels == 2)
 	{
-		if (pRequestedOutputFormat->nChannels != pInputFormat->nChannels)
+		if (pRequestedOutputFormat->nChannels != pInputFormat->nChannels &&
+			pRequestedOutputFormat->nChannels != 6)
 		{
 			SET_SUPPORTED_FIELD(nChannels, pInputFormat->nChannels);
-		}
-	}
-	else if (pInputFormat->nChannels == 6)
-	{
-		if (pRequestedOutputFormat->nChannels != 1 || pRequestedOutputFormat->nChannels != 2)
-		{
-			SET_SUPPORTED_FIELD(nChannels, 1);
 		}
 	}
 	else
 	{
 		SET_SUPPORTED_FIELD(nChannels, 1);
-		result = 1;
 	}
 
 #undef SET_SUPPORTED_FIELD

--- a/src/FAudio_internal.c
+++ b/src/FAudio_internal.c
@@ -884,6 +884,27 @@ void FAudio_INTERNAL_SetDefaultMatrix(
 	);
 }
 
+void FAudioVoice_INTERNAL_FreeEffectChain(FAudioVoice *voice)
+{
+	uint32_t i;
+
+	if (voice->effects.count == 0)
+	{
+		return;
+	}
+
+	for (i = 0; i < voice->effects.count; i += 1)
+	{
+		FAPOBase_Release((FAPOBase *)voice->effects.desc[i].pEffect);
+	}
+
+	FAudio_free(voice->effects.desc);
+	FAudio_free(voice->effects.parameters);
+	FAudio_free(voice->effects.parameterSizes);
+	FAudio_free(voice->effects.parameterUpdates);
+	FAudio_free(voice->effects.inPlaceProcessing);
+}
+
 /* PCM Decoding */
 
 void (*FAudio_INTERNAL_Convert_S8_To_F32)(

--- a/src/FAudio_internal.h
+++ b/src/FAudio_internal.h
@@ -203,6 +203,7 @@ void FAudio_INTERNAL_SetDefaultMatrix(
 	uint32_t srcChannels,
 	uint32_t dstChannels
 );
+void FAudioVoice_INTERNAL_FreeEffectChain(FAudioVoice *voice);
 void FAudio_INTERNAL_InitConverterFunctions(uint8_t hasSSE2, uint8_t hasNEON);
 
 #define DECODE_FUNC(type) \

--- a/src/FAudio_internal.h
+++ b/src/FAudio_internal.h
@@ -109,8 +109,10 @@ struct FAudio
 	#define EXTRA_DECODE_PADDING 2
 	uint32_t decodeSamples;
 	uint32_t resampleSamples;
+	uint32_t effectChainSamples;
 	float *decodeCache;
 	float *resampleCache;
+	float *effectChainCache;
 };
 
 struct FAudioVoice
@@ -128,12 +130,14 @@ struct FAudioVoice
 		void **parameters;
 		uint32_t *parameterSizes;
 		uint8_t *parameterUpdates;
+		uint8_t *inPlaceProcessing;
 	} effects;
 	FAudioFilterParameters filter;
 	FAudioFilterState *filterState;
 
 	float volume;
 	float *channelVolume;
+	uint32_t outputChannels;
 
 	union
 	{
@@ -193,6 +197,7 @@ struct FAudioVoice
 void FAudio_INTERNAL_UpdateEngine(FAudio *audio, float *output);
 void FAudio_INTERNAL_ResizeDecodeCache(FAudio *audio, uint32_t size);
 void FAudio_INTERNAL_ResizeResampleCache(FAudio *audio, uint32_t size);
+void FAudio_INTERNAL_ResizeEffectChainCache(FAudio *audio, uint32_t samples);
 void FAudio_INTERNAL_SetDefaultMatrix(
 	float *matrix,
 	uint32_t srcChannels,

--- a/utils/testreverb/audio.cpp
+++ b/utils/testreverb/audio.cpp
@@ -7,6 +7,13 @@
 
 #define RESOURCE_PATH "utils/testreverb/resources"
 
+const char *audio_voice_type_names[3] = 
+{
+	"Source Voice",
+	"Submix Voice",
+	"Mastering Voice"
+};
+
 const char *audio_sample_filenames[] =
 {
 	RESOURCE_PATH"/snaredrum_forte.wav",
@@ -92,19 +99,14 @@ const size_t audio_reverb_preset_count = sizeof(audio_reverb_preset_names) / siz
 
 PFN_AUDIO_DESTROY_CONTEXT audio_destroy_context = NULL;
 PFN_AUDIO_CREATE_VOICE audio_create_voice = NULL;
-PFN_AUDIO_VOICE_DESTROY audio_voice_destroy = NULL;
-PFN_AUDIO_VOICE_SET_VOLUME audio_voice_set_volume = NULL;
-PFN_AUDIO_VOICE_SET_FREQUENCY audio_voice_set_frequency = NULL;
-
 PFN_AUDIO_WAVE_LOAD audio_wave_load = NULL;
 PFN_AUDIO_WAVE_PLAY audio_wave_play = NULL;
-
 PFN_AUDIO_EFFECT_CHANGE audio_effect_change = NULL;
 
-extern AudioContext *xaudio_create_context(bool output_5p1);
-extern AudioContext *faudio_create_context(bool output_5p1);
+extern AudioContext *xaudio_create_context(bool output_5p1, AudioVoiceType effect_on_voice);
+extern AudioContext *faudio_create_context(bool output_5p1, AudioVoiceType effect_on_voice);
 
-AudioContext *audio_create_context(AudioEngine p_engine, bool output_5p1)
+AudioContext *audio_create_context(AudioEngine p_engine, bool output_5p1, AudioVoiceType effect_on_voice)
 {
 	if (audio_reverb_presets == NULL)
 	{
@@ -122,11 +124,11 @@ AudioContext *audio_create_context(AudioEngine p_engine, bool output_5p1)
 	{
 		#ifdef HAVE_XAUDIO2
 		case AudioEngine_XAudio2:
-			return xaudio_create_context(output_5p1);
+			return xaudio_create_context(output_5p1, effect_on_voice);
 		#endif
 
 		case AudioEngine_FAudio:
-			return faudio_create_context(output_5p1);
+			return faudio_create_context(output_5p1, effect_on_voice);
 		
 		default:
 			return NULL;

--- a/utils/testreverb/audio.h
+++ b/utils/testreverb/audio.h
@@ -9,11 +9,10 @@
 #endif
 
 const float PI = 3.14159265358979323846f;
+const uint32_t SAMPLERATE = 44100;
 
 // types
 struct AudioContext;
-struct AudioVoice;
-struct AudioFilter;
 
 enum AudioEngine {
 	AudioEngine_XAudio2,
@@ -24,6 +23,12 @@ enum AudioSampleWave {
 	AudioWave_SnareDrum01 = 0,
 	AudioWave_SnareDrum02,
 	AudioWave_SnareDrum03,
+};
+
+enum AudioVoiceType {
+	AudioVoiceType_Source = 0,
+	AudioVoiceType_Submix,
+	AudioVoiceType_Master
 };
 
 #pragma pack(push, 1)
@@ -73,6 +78,8 @@ struct ReverbParameters
 
 #pragma pack(pop)
 
+extern const char *audio_voice_type_names[3];
+
 extern const char *audio_sample_filenames[];
 extern const char *audio_stereo_filenames[];
 extern const char *audio_reverb_preset_names[];
@@ -80,12 +87,8 @@ extern const ReverbI3DL2Parameters audio_reverb_presets_i3dl2[];
 extern const ReverbParameters	   *audio_reverb_presets;
 extern const size_t				   audio_reverb_preset_count;
 
-typedef void(*PFN_AUDIO_DESTROY_CONTEXT)(AudioContext *p_context);
-
-typedef AudioVoice *(*PFN_AUDIO_CREATE_VOICE)(AudioContext *p_context, float *p_buffer, size_t p_buffer_size, int p_sample_rate, int p_num_channels);
-typedef void (*PFN_AUDIO_VOICE_DESTROY)(AudioVoice *p_voice);
-typedef void (*PFN_AUDIO_VOICE_SET_VOLUME)(AudioVoice *p_voice, float p_volume);
-typedef void (*PFN_AUDIO_VOICE_SET_FREQUENCY)(AudioVoice *p_vioce, float p_frequency);
+typedef void (*PFN_AUDIO_DESTROY_CONTEXT)(AudioContext *p_context);
+typedef void (*PFN_AUDIO_CREATE_VOICE)(AudioContext *p_context, float *p_buffer, size_t p_buffer_size, int p_sample_rate, int p_num_channels);
 
 typedef void (*PFN_AUDIO_WAVE_LOAD)(AudioContext *p_context, AudioSampleWave sample, bool stereo);
 typedef void (*PFN_AUDIO_WAVE_PLAY)(AudioContext *p_context);
@@ -93,13 +96,10 @@ typedef void (*PFN_AUDIO_WAVE_PLAY)(AudioContext *p_context);
 typedef void(*PFN_AUDIO_EFFECT_CHANGE)(AudioContext *p_context, bool p_enabled, ReverbParameters *p_params);
 
 // API
-AudioContext *audio_create_context(AudioEngine p_engine, bool output_5p1);
+AudioContext *audio_create_context(AudioEngine p_engine, bool output_5p1, AudioVoiceType effect_on_voice);
 
 extern PFN_AUDIO_DESTROY_CONTEXT audio_destroy_context;
 extern PFN_AUDIO_CREATE_VOICE audio_create_voice;
-extern PFN_AUDIO_VOICE_DESTROY audio_voice_destroy;
-extern PFN_AUDIO_VOICE_SET_VOLUME audio_voice_set_volume;
-extern PFN_AUDIO_VOICE_SET_FREQUENCY audio_voice_set_frequency;
 
 extern PFN_AUDIO_WAVE_LOAD audio_wave_load;
 extern PFN_AUDIO_WAVE_PLAY audio_wave_play;

--- a/utils/testreverb/testreverb.cpp
+++ b/utils/testreverb/testreverb.cpp
@@ -33,7 +33,7 @@ void FAudioTool_Update()
 	bool update_effect = false;
 
 	// gui
-	int window_y = next_window_dims(0, 50);
+	int window_y = next_window_dims(0, 80);
 	ImGui::Begin("Output Audio Engine");
 
 		static int audio_engine = (int)AudioEngine_FAudio;
@@ -44,6 +44,9 @@ void FAudioTool_Update()
 
 		static bool output_5p1 = false;
 		update_engine |= ImGui::Checkbox("5.1 channel output", &output_5p1);
+
+		static int32_t voice_index = (int32_t) AudioVoiceType_Submix;
+		update_engine |= ImGui::Combo("Apply effect to", &voice_index, audio_voice_type_names, 3);
 
 	ImGui::End();
 
@@ -67,8 +70,8 @@ void FAudioTool_Update()
 		
 		static bool effect_enabled = false;
 		update_effect |= ImGui::Checkbox("Enabled", &effect_enabled);
-		
-		static int preset_index = -1;
+
+		static int32_t preset_index = -1;
 		static ReverbParameters reverb_params = {
 			100.0f,
 			40,
@@ -97,7 +100,7 @@ void FAudioTool_Update()
 
 	ImGui::End();
 
-	window_y = next_window_dims(window_y, 630);
+	window_y = next_window_dims(window_y, 600);
 	ImGui::Begin("FAudio Tune Detail");
 
 		int ReverbDelay = reverb_params.ReverbDelay;
@@ -167,7 +170,7 @@ void FAudioTool_Update()
 		{
 			audio_destroy_context(player);
 		}
-		player = audio_create_context((AudioEngine) audio_engine, output_5p1);
+		player = audio_create_context((AudioEngine) audio_engine, output_5p1, (AudioVoiceType) voice_index);
 	}
 
 	if (update_wave | update_engine)


### PR DESCRIPTION
This fixes the issue we noticed when testing PR #12 with 5.1 surround sound.

As you predicted most of the work was in SetEffectChain and ProcessEffectChain. In addition to SetOutputMatrix I also had to touch SetOutputVoices and change the order of things that depend on the number of output channels in the Create...Voice functions.

SetEffectChain now validates the new effect chain and changing the effect chain is supported. As the last step it checks if in-place processing is supported by the effect at all and if it's possible in the current configuration.

ProcessEffectChain alternates between a 'global' effectChainCache and the original buffer when in-place processing isn't possible to allow longer chains.

To test this I extended the testreverb utility with a submix voice and the ability the add the effect chain to either the source, the submix, or the mastering voice. I tested Dust on Linux and JetSetRadio/Capsized on Windows and verified these still work.

The effect chain validation exposed a bug in AudioFXReverb_IsOutputFormatSupported. The last commit fixes that.
