### PR TITLE
Fix multichannel submix voices

### DIFF
--- a/src/FAudio_internal.c
+++ b/src/FAudio_internal.c
@@ -609,7 +609,7 @@ static void FAudio_INTERNAL_MixSubmix(FAudioSubmixVoice *voice)
 		voice->mix.inputCache,
 		voice->mix.inputSamples,
 		voice->audio->resampleCache,
-		voice->mix.outputSamples
+		voice->mix.outputSamples * voice->mix.inputChannels
 	);
 
 	/* Submix overall volume is applied _before_ effects/filters, blech! */


### PR DESCRIPTION
While working on PR #15 I noticed submix voices with more than 1 channel did not play back correctly. The sound seems stretched out and choppy. You can reproduce the issue with the extended testreverb utility from PR #15. Just choose stereo sound, you don't have to enable the reverb effect.

This small change fixes the issue and does not seem to cause any other problems.